### PR TITLE
Smal fixes and more documentation

### DIFF
--- a/ads1115/include/ads1115/ads1115.hpp
+++ b/ads1115/include/ads1115/ads1115.hpp
@@ -3,8 +3,8 @@
 
 // ADS1115
 #include "ads1115/config.hpp"
-#include "ads1115/threshold.hpp"
 #include "ads1115/detail/ads1115_export.h"
+#include "ads1115/threshold.hpp"
 
 // i2c-device
 #include "i2c-device/device.hpp"
@@ -22,7 +22,7 @@ namespace ADS1115
      */
     class ADS1115_EXPORT ADS1115
     {
-        //! The linux filedescriptor to the i2c device in use.
+        //! The generic i2c device in use.
         i2c::i2c_device<> m_device;
 
         //! The i2c bus address of the ADS1115.

--- a/ads1115/include/ads1115/config.hpp
+++ b/ads1115/include/ads1115/config.hpp
@@ -2,14 +2,21 @@
 #define ADS1115_OPTIONS_HPP_
 
 // ADS1115
-#include "ads1115/parameters.hpp"
 #include "ads1115/detail/ads1115_export.h"
+#include "ads1115/parameters.hpp"
 
 // stl
 #include <cstdint>
 
 namespace ADS1115
 {
+    /*! The Config struct represents the config register of the ADS1115.
+     *
+     * The config register of the ADS1115 is consists of 16 bit which configure the device. The
+     * members of this struct map to the configuration options described in the datasheet and can
+     * span more than one bit. A `to_bytes()` member function is provided to convert the struct to a
+     * `std::uint16_t` which can be writen to the config register of the ADS1115.
+     */
     struct ADS1115_EXPORT Config {
 
         Config() = default;
@@ -26,6 +33,9 @@ namespace ADS1115
 
         bool operator==(const Config& other) const = default;
 
+        /*! Converts the struct to a `std::uint16_t` which can be writen to the config register of
+         * the ADS1115.
+         */
         std::uint16_t to_bytes() const;
     };
 } // namespace ADS1115

--- a/ads1115/include/ads1115/parameters.hpp
+++ b/ads1115/include/ads1115/parameters.hpp
@@ -7,11 +7,16 @@
 
 namespace ADS1115
 {
+    //! Address of the conversion register.
     constexpr std::uint8_t conv_reg_addr = 0x00;
+    //! Address of the config register.
     constexpr std::uint8_t conf_reg_addr = 0x01;
+    //! Address of the low threshold register.
     constexpr std::uint8_t lo_thresh_reg_addr = 0x02;
+    //! Address of the high threshold register.
     constexpr std::uint8_t hi_thresh_reg_addr = 0x03;
 
+    //! This Enum describes the possible i2c bus addresses of a ADS1115.
     enum class ADDR : std::uint8_t {
         GND = 0x48,
         VDD = 0x49,
@@ -19,10 +24,22 @@ namespace ADS1115
         SCL = 0x4b,
     };
 
+    /*! This Enum describes the possible values that can be writen to the operational status
+     * bit while the ADS1115 is in power down mode.
+     *
+     * The operational status bit of the config register can only be writen when the ADS1115 is in
+     * power down mode.
+     */
     enum class OS : std::uint16_t {
+        //! No effect when the config register is writen.
         NON = 0x0000,
+        //! Starts a new conversion when the conversion register is writen.
         SINGLE_CONV = 0x8000,
     };
+
+    /*! This enum describes the possible values of the multiplexer bits of the configuration
+     * register. It is used to select the inputs from which the ADS1115 reads data.
+     */
     enum class MUX : std::uint16_t {
         AIN0_AIN1 = 0x0000,
         AIN0_AIN3 = 0x1000,
@@ -33,41 +50,93 @@ namespace ADS1115
         AIN2_GND = 0x6000,
         AIN3_GND = 0x7000,
     };
+
+    /*! This enum describes the possible values for the programable gain amplifier bits of the
+     * config register. This effectefly defines the full-scale of the analog inputs above which the
+     * output will be cliped.
+     */
     enum class PGA : std::uint16_t {
+        //! FS = \f$\pm\f$ 6.144V
         FS_6_144 = 0x0000,
+        //! FS = \f$\pm\f$ 4.096V
         FS_4_096 = 0x0200,
+        //! FS = \f$\pm\f$ 2.048V
         FS_2_048 = 0x0400,
+        //! FS = \f$\pm\f$ 1.024V
         FS_1_024 = 0x0600,
+        //! FS = \f$\pm\f$ 0.512V
         FS_0_512 = 0x0800,
+        //! FS = \f$\pm\f$ 0.256V
         FS_0_256 = 0x0a00,
     };
+
+    /*! This enum describes the operational modes of the ADS1115.
+     */
     enum class MODE : std::uint16_t {
+        //! Sets the ADS1115 to continuous conversion mode.
         CONT_CONV = 0x0000,
+        //! Sets the ADS1115 to power-down single-shot mode.
         SINGLE_CONV = 0x0100,
     };
 
+    /*! This enum describes the possible data rates of the ADS1115.
+     */
     enum class DR : std::uint16_t {
+        //! DR = 8 SPS
         SPS_8 = 0x0000,
+        //! DR = 16 SPS
         SPS_16 = 0x0020,
+        //! DR = 32 SPS
         SPS_32 = 0x0040,
+        //! DR = 64 SPS
         SPS_64 = 0x0060,
+        //! DR = 128 SPS
         SPS_128 = 0x0080,
+        //! DR = 250 SPS
         SPS_250 = 0x00a0,
+        //! DR = 475 SPS
         SPS_475 = 0x00c0,
+        //! DR = 860 SPS
         SPS_860 = 0x00e0,
     };
+
+    /*! This enum describes the mode of the comparator of the ADS1115.
+     */
     enum class COMP_MODE : std::uint16_t {
+        //! Traditional comparator with hysteresis
         TRAD_COMP = 0x0000,
+        //! Window comparator
         WINDOW_COMP = 0x0010,
     };
+
+    /*! This enum describes the comparator polarity of the ADS1115.
+     * This enum controls the polarity of the ALERT/RDY pin. When COMP_POL::LOW the comparator
+     * output is active low. When COMP_POL::HIGH the ALERT/RDY pin is active high.
+     */
     enum class COMP_POL : std::uint16_t {
         LOW = 0x0000,
         HIGH = 0x0008,
     };
+
+    /*! This enum describes the latching behaviour of the comparator.
+     * This enum controls whether the ALERT/RDY pin latches once asserted or clears once conversions
+     * are within the margin of the upper and lower threshold values. When COMP_LAT::NON_LATCHING,
+     * the ALERT/RDY pin does not latch when asserted. When COMP_LAT::LATCHING, the asserted
+     * ALERT/RDY pin remains latched until conversion data are read by the master or an appropriate
+     * SMBus alert response is sent by the master, the device responds with its address, and it is
+     * the lowest address currently asserting the ALERT/RDY bus line.
+     */
     enum class COMP_LAT : std::uint16_t {
         NON_LATCHING = 0x0000,
         LATCHING = 0x0004,
     };
+
+    /*! This enum describes the state of the comparator queue.
+     * This enum performs two functions. When set to COMP_QUE::DISABLE_COMP, they disable the
+     * comparator function and put the ALERT/RDY pin into a high state. When set to any other value,
+     * they control the number of successive conversions exceeding the upper or lower thresholds
+     * required before asserting the ALERT/RDY pin.
+     */
     enum class COMP_QUE : std::uint16_t {
         ONE_CONV = 0x0000,
         TWO_CONV = 0x0001,

--- a/ads1115/src/ads1115.cpp
+++ b/ads1115/src/ads1115.cpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <stdexcept>
 #include <thread>
 
@@ -84,12 +85,13 @@ namespace ADS1115
 
     double ADS1115::toVoltage(const std::int16_t value) const
     {
-        return value * pga_voltage_map.at(m_config.pga) / 32768;
+        return value * pga_voltage_map.at(m_config.pga) / std::numeric_limits<std::int16_t>::max();
     }
 
     std::int16_t ADS1115::fromVoltage(const double value) const
     {
-        return static_cast<std::int16_t>(value * 32768 / pga_voltage_map.at(m_config.pga));
+        return static_cast<std::int16_t>(
+            value * std::numeric_limits<std::int16_t>::max() / pga_voltage_map.at(m_config.pga));
     }
 
     /*******************
@@ -140,8 +142,12 @@ namespace ADS1115
 
     void ADS1115::setRegThreshold(const Threshold threshold)
     {
-        m_device.write_word_data(lo_thresh_reg_addr, std::bit_cast<std::uint16_t>(threshold.getLow()));
-        m_device.write_word_data(hi_thresh_reg_addr, std::bit_cast<std::uint16_t>(threshold.getHigh()));
+        m_device.write_word_data(
+            lo_thresh_reg_addr,
+            std::bit_cast<std::uint16_t>(threshold.getLow()));
+        m_device.write_word_data(
+            hi_thresh_reg_addr,
+            std::bit_cast<std::uint16_t>(threshold.getHigh()));
         m_threshold = threshold;
     }
 

--- a/ads1115/src/ads1115.cpp
+++ b/ads1115/src/ads1115.cpp
@@ -12,9 +12,6 @@
 #include <bit>
 #include <chrono>
 #include <cstdint>
-#include <cstdio>
-#include <filesystem>
-#include <fstream>
 #include <limits>
 #include <stdexcept>
 #include <thread>


### PR DESCRIPTION
Added some documentation.

Also:
 * Use of the `numeric_limits` api instead of a hardcoded value.
 * Remove unused headers from `ads1115.hpp`.
